### PR TITLE
Support to reconfigure LaserScanBoxFilter in filter2

### DIFF
--- a/include/laser_filters/angular_bounds_filter.h
+++ b/include/laser_filters/angular_bounds_filter.h
@@ -63,6 +63,11 @@ namespace laser_filters
         return true;
       }
 
+      bool reconfigure()
+      {
+        return false;
+      }
+
       virtual ~LaserScanAngularBoundsFilter(){}
 
       bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan){

--- a/include/laser_filters/angular_bounds_filter_in_place.h
+++ b/include/laser_filters/angular_bounds_filter_in_place.h
@@ -62,6 +62,11 @@ namespace laser_filters
         return true;
       }
 
+      bool reconfigure()
+      {
+        return false;
+      }
+
       virtual ~LaserScanAngularBoundsFilterInPlace(){}
 
       bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan){

--- a/include/laser_filters/array_filter.h
+++ b/include/laser_filters/array_filter.h
@@ -84,6 +84,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   /** \brief Update the filter and get the response
    * \param scan_in The new scan to filter
    * \param scan_out The filtered scan

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -120,6 +120,11 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
              x_min_set && y_min_set && z_min_set;
     }
 
+    bool reconfigure()
+    {
+      return false;
+    }
+
     bool update(
         const sensor_msgs::msg::LaserScan &input_scan,
         sensor_msgs::msg::LaserScan &output_scan)

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -72,6 +72,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
     {
       up_and_running_ = true;
       double min_x, min_y, min_z, max_x, max_y, max_z;
+      bool reconfigure_trigger;
       bool box_frame_set = getParam("box_frame", box_frame_);
       bool x_max_set = getParam("max_x", max_x);
       bool y_max_set = getParam("max_y", max_y);
@@ -79,6 +80,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
       bool x_min_set = getParam("min_x", min_x);
       bool y_min_set = getParam("min_y", min_y);
       bool z_min_set = getParam("min_z", min_z);
+      getParam("reconfigure_trigger", reconfigure_trigger);
 
       max_.setX(max_x);
       max_.setY(max_y);
@@ -122,7 +124,39 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
 
     bool reconfigure()
     {
-      return false;
+      bool reconfigure_trigger;
+      getParam("reconfigure_trigger", reconfigure_trigger);
+      if (reconfigure_trigger)
+      {
+        double min_x, min_y, min_z, max_x, max_y, max_z;
+        getParam("max_x", max_x);
+        getParam("max_y", max_y);
+        getParam("max_z", max_z);
+        getParam("min_x", min_x);
+        getParam("min_y", min_y);
+        getParam("min_z", min_z);
+
+        max_.setX(max_x);
+        max_.setY(max_y);
+        max_.setZ(max_z);
+        min_.setX(min_x);
+        min_.setY(min_y);
+        min_.setZ(min_z);
+
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set max_x to %.3f", max_x);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set max_y to %.3f", max_y);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set max_z to %.3f", max_z);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set min_x to %.3f", min_x);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set min_y to %.3f", min_y);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Set min_z to %.3f", min_z);
+        RCLCPP_INFO(get_logger(), "[LaserScanBoxFilter::reconfigure] Reconfigure done");
+        return true;
+      }
+      else
+      {
+        RCLCPP_ERROR(get_logger(), "[LaserScanBoxFilter::reconfigure] Reconfigure is disabled");
+        return false;
+      }
     }
 
     bool update(

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -74,6 +74,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   virtual ~LaserScanFootprintFilter()
   {
   }

--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -70,6 +70,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   virtual ~LaserScanIntensityFilter(){}
 
   bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan)

--- a/include/laser_filters/interpolation_filter.h
+++ b/include/laser_filters/interpolation_filter.h
@@ -56,6 +56,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   virtual ~InterpolationFilter()
   { 
   }

--- a/include/laser_filters/median_filter.h
+++ b/include/laser_filters/median_filter.h
@@ -88,6 +88,11 @@ namespace laser_filters
       return true;
     };
 
+    bool reconfigure()
+    {
+      return false;
+    }
+
     /** \brief Update the filter and get the response
    * \param scan_in The new scan to filter
    * \param scan_out The filtered scan

--- a/include/laser_filters/range_filter.h
+++ b/include/laser_filters/range_filter.h
@@ -78,6 +78,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   virtual ~LaserScanRangeFilter()
   {
 

--- a/include/laser_filters/scan_mask_filter.h
+++ b/include/laser_filters/scan_mask_filter.h
@@ -89,6 +89,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   virtual ~LaserScanMaskFilter()
   {
   }

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -98,6 +98,11 @@ public:
     return true;
   }
 
+  bool reconfigure()
+  {
+    return false;
+  }
+
   ////////////////////////////////////////////////////////////////////////////////
   virtual ~ScanShadowsFilter () { }
 

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -222,6 +222,12 @@ public:
     return true;
   }
   /////////////////////////////////////////////////////
+
+  bool reconfigure()
+  {
+    return false;
+  }
+
   bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& output_scan){
     output_scan = input_scan;
     std::vector<bool> valid_ranges(output_scan.ranges.size(), false);


### PR DESCRIPTION
#### NOTICE
- Only works for LaserScanBoxFilter in filter2

#### Requirement
- Customized version of the [filters](https://github.com/mk-system/filters/commit/54fec2814900b0b3d99a91911050a14dbaee9e21) in https://github.com/mk-system/filters/pull/2
- Parameter `reconfigure_trigger`
```
scan_to_scan_filter_chain:
  ros__parameters:
    filter1:
      ...
      ...
      ...
    filter2:
      name: laser_scan_box_filter
      type: laser_filters/LaserScanBoxFilter
      params:
        ...
        ...
        ...
        reconfigure_trigger: true
```

#### Reconfigure command set
- `ros2 param set scan_to_scan_filter_chain filter2.params.max_x 2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.max_y 2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.max_z 2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.min_x -2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.min_y -2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.min_z -2.0`
- `ros2 param set scan_to_scan_filter_chain filter2.params.reconfigure_trigger True`
